### PR TITLE
Make compatible with surefire reuseForks=false

### DIFF
--- a/sonar-jacoco-listeners/src/main/java/org/sonar/java/jacoco/JUnitListener.java
+++ b/sonar-jacoco-listeners/src/main/java/org/sonar/java/jacoco/JUnitListener.java
@@ -27,24 +27,18 @@ import org.junit.runner.notification.RunListener;
  */
 public class JUnitListener extends RunListener {
 
-  protected final JacocoController jacoco;
-
-  public JUnitListener() {
-    this(JacocoController.getInstance());
-  }
-
-  JUnitListener(JacocoController jacoco) {
-    this.jacoco = jacoco;
+  protected JacocoController getController() {
+	  return JacocoController.getInstance();
   }
 
   @Override
   public void testStarted(Description description) {
-    jacoco.onTestStart(getName(description));
+	  getController().onTestStart(getName(description));
   }
 
   @Override
   public void testFinished(Description description) {
-    jacoco.onTestFinish(getName(description));
+	  getController().onTestFinish(getName(description));
   }
 
   private static String getName(Description description) {


### PR DESCRIPTION
JacocoController.getInstance() is executed too soon in case of surefire option reuseForks=false.
In this configuration, the listener is created without javaagent enabled. It is enabled only when the VM is forked while starting a test.